### PR TITLE
Get full tweet instead of truncated version

### DIFF
--- a/twecoll
+++ b/twecoll
@@ -725,11 +725,11 @@ def tweets(args):
   while True:
     try:
       if args.query:
-        url = 'https://api.twitter.com/1.1/search/tweets.json?q=%s&result_type=recent'
+        url = 'https://api.twitter.com/1.1/search/tweets.json?q=%s&result_type=recent&tweet_mode=extended'
       elif args.l:
-        url = 'https://api.twitter.com/1.1/lists/statuses.json?slug='+args.l+'&owner_screen_name=%s'
+        url = 'https://api.twitter.com/1.1/lists/statuses.json?slug='+args.l+'&owner_screen_name=%s&tweet_mode=extended'
       else:
-        url = 'https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=%s&count=100'
+        url = 'https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=%s&count=100&tweet_mode=extended'
       if max_id:
         url += '&max_id=%i' % max_id
       conn = urllib2.urlopen(url % args.screen_name)
@@ -767,9 +767,9 @@ def tweets(args):
       max_id = min(max_id, tweet['id']) or tweet['id']
       if args.query or args.l:
         f.write('%30s @%-20s %s\n' % (tweet['created_at'], \
-          tweet['user']['screen_name'], tweet['text'].replace('\n', ' ')))
+          tweet['user']['screen_name'], tweet['full_text'].replace('\n', ' ')))
       else:
-        f.write('%30s %s\n' % (tweet['created_at'], tweet['text'].replace('\n', ' ')))
+        f.write('%30s %s\n' % (tweet['created_at'], tweet['full_text'].replace('\n', ' ')))
 
 # find out remaining calls left by endpoint
 class StatsAction(argparse.Action):


### PR DESCRIPTION
Per default the Twitter API returns truncated tweets if they are over 140 characters long. Because URLs (including uploaded media) and reply-usernames don't count against the limit anymore this happens more often now. 

The 'extended_tweet=true' parameter ensures that the full tweet gets retrieved. In the returned json the tweet isn't called 'text' anymore, but 'full_text'.

I wasn't able to find a proper documentation for it, but it's in the change notes (at the moment): https://dev.twitter.com/overview/api/upcoming-changes-to-tweets#id48