### PR TITLE
speed up collecting tweets

### DIFF
--- a/twecoll
+++ b/twecoll
@@ -725,9 +725,9 @@ def tweets(args):
   while True:
     try:
       if args.query:
-        url = 'https://api.twitter.com/1.1/search/tweets.json?q=%s&result_type=recent&tweet_mode=extended'
+        url = 'https://api.twitter.com/1.1/search/tweets.json?q=%s&result_type=recent&count=100&tweet_mode=extended'
       elif args.l:
-        url = 'https://api.twitter.com/1.1/lists/statuses.json?slug='+args.l+'&owner_screen_name=%s&tweet_mode=extended'
+        url = 'https://api.twitter.com/1.1/lists/statuses.json?slug='+args.l+'&owner_screen_name=%s&count=100&tweet_mode=extended'
       else:
         url = 'https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=%s&count=100&tweet_mode=extended'
       if max_id:


### PR DESCRIPTION
Per default the tweets.json endpoint returns 15 Tweets per request. Maximum is 100 Tweets. By setting this variable tweet collection is up to 6.6 times faster.

https://dev.twitter.com/rest/reference/get/search/tweets
https://dev.twitter.com/rest/reference/get/lists/statuses (no default or maximum value in the docs)

![pi raspberrypi 192 168 178 68 - byobu 2017-07-28 14 12 55](https://user-images.githubusercontent.com/1390793/28716726-0a4e0010-739f-11e7-9e58-235247cc108c.png)