### PR TITLE
fix Dockerfile ADD command - add missing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --upgrade cffi
 RUN pip install cairocffi
 
 RUN git clone https://github.com/jdevoo/twecoll.git
-ADD .twecoll /root
+ADD ./twecoll /root
 
 WORKDIR /app
 VOLUME /app


### PR DESCRIPTION
`ADD .twecoll /root` command fails with below message:

`ADD failed: stat /var/lib/docker/tmp/docker-builder130437154/.twecoll: no such file or directory`